### PR TITLE
Widen userMentions regex to support Jira username with numbers and dot

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -1,7 +1,7 @@
 var functions = {
   getUserMentionsFromComment: function(commentBody) {
     return new Promise(function(resolve, reject) {
-      let userMentions = commentBody.match(/(\[~[a-zA-Z]+\])/g)
+      let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.]+\])/g)
       if (userMentions.length > 0) {
         return resolve(userMentions)
       } else {


### PR DESCRIPTION
As I used in my organization, there are some Jira username containing numbers and dot (eg: v.anhdq20 for me). So we should support these.